### PR TITLE
Fix golangci-lint installation error in copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,12 +29,9 @@ jobs:
           cache: true
 
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-          # Only install, don't run linting (Copilot will do that)
-          skip-cache: false
-          args: --version
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Verify golangci-lint installation
         run: golangci-lint --version


### PR DESCRIPTION
## Problem
PR #39 introduced a `copilot-setup-steps.yml` file, but it's failing with this error:
```
Error: unknown flag: --version
Failed executing command with error: unknown flag: --version
Error: golangci-lint exit with code 3
```

The issue is that `golangci/golangci-lint-action@v6` was trying to run `golangci-lint run --version`, but the `--version` flag doesn't work with the `run` subcommand.

## Solution
- **Replace the action** with direct installation using the official golangci-lint installation script
- **Use `curl` and the official install script** from golangci-lint repository
- **Add golangci-lint to PATH** so it's available for the Copilot coding agent
- **Remove the problematic `args: --version`** parameter

## Changes
```yaml
# Before (broken)
- name: Install golangci-lint
  uses: golangci/golangci-lint-action@v6
  with:
    version: latest
    args: --version  # This was causing the error

# After (working)
- name: Install golangci-lint
  run: |
    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
    echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
```

## Testing
This approach uses the same installation method recommended in the official golangci-lint documentation and should work reliably in the GitHub Actions environment.

Fixes the installation error from PR #39 and ensures golangci-lint is properly available for the Copilot coding agent.