### PR TITLE
Add shared Git hooks system for branch protection

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Pre-commit hook to prevent commits directly to main branch
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$branch" = "main" ]; then
+  echo "🚫 ERROR: Direct commits to main branch are not allowed!"
+  echo "💡 Please create a feature branch and submit a pull request."
+  echo ""
+  echo "To create a new branch:"
+  echo "  git checkout -b feature/your-feature-name"
+  echo ""
+  echo "To bypass this check (NOT RECOMMENDED):"
+  echo "  git commit --no-verify"
+  exit 1
+fi

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -1,0 +1,43 @@
+# Git Hooks Setup
+
+This repository includes shared Git hooks to maintain code quality and workflow standards.
+
+## 🔧 Installation
+
+Run this command **once** after cloning the repository:
+
+```bash
+# On Unix/Linux/macOS:
+./install-hooks.sh
+
+# On Windows (PowerShell):
+.\install-hooks.ps1
+```
+
+## 🛡️ Installed Hooks
+
+### Pre-commit Hook
+- **Purpose**: Prevents direct commits to the `main` branch
+- **Action**: Blocks commits and suggests creating a feature branch
+- **Bypass**: Use `git commit --no-verify` (not recommended)
+
+## 📋 Team Workflow
+
+1. **Always work on feature branches**: `git checkout -b feature/your-feature`
+2. **Create pull requests** for all changes to main branch
+3. **Let the hooks guide you** - they're there to help maintain quality
+
+## 🔄 Updating Hooks
+
+When hooks are updated in the repository:
+1. Pull the latest changes: `git pull`  
+2. Re-run the installation: `./install-hooks.sh`
+
+## 🚫 Main Branch Protection
+
+The pre-commit hook prevents these common mistakes:
+- Accidental commits directly to `main`
+- Bypassing the pull request workflow
+- Breaking the protected branch workflow
+
+This works in combination with GitHub's branch protection rules for complete protection.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 A Terminal User Interface for Azure Application Insights, specifically designed for Microsoft Dynamics 365 Business Central developers. Built with Go and the Charm Bracelet TUI ecosystem.
 
+## 🚀 Quick Start
+
+### 1. Clone and Setup
+```bash
+git clone https://github.com/FBakkensen/bc-insights-tui.git
+cd bc-insights-tui
+
+# Install Git hooks (prevents commits to main branch)
+./install-hooks.sh          # Unix/Linux/macOS
+# OR
+.\install-hooks.ps1         # Windows PowerShell
+```
+
+### 2. Build and Run
+```bash
+go build
+./bc-insights-tui           # Unix/Linux/macOS
+# OR
+.\bc-insights-tui.exe       # Windows
+```
+
 ## 🎯 Project Overview
 
 BC Insights TUI provides a keyboard-driven, command palette-based interface for querying and analyzing Business Central telemetry data stored in Azure Application Insights. The tool is optimized for the dynamic nature of Business Central's telemetry schema, where event structure is determined by the `eventId` field.

--- a/install-hooks.ps1
+++ b/install-hooks.ps1
@@ -1,0 +1,18 @@
+Write-Host "Installing Git hooks..." -ForegroundColor Cyan
+
+if (Test-Path ".githooks\pre-commit") {
+    Write-Host "Found .githooks\pre-commit" -ForegroundColor Yellow
+    
+    if (!(Test-Path ".git\hooks")) {
+        New-Item -ItemType Directory -Path ".git\hooks" -Force | Out-Null
+        Write-Host "Created .git\hooks directory" -ForegroundColor Yellow
+    }
+    
+    Copy-Item ".githooks\pre-commit" ".git\hooks\pre-commit" -Force
+    icacls ".git\hooks\pre-commit" /grant Everyone:F | Out-Null
+    
+    Write-Host "Installed: pre-commit hook" -ForegroundColor Green
+    Write-Host "Git hooks installation complete!" -ForegroundColor Green
+} else {
+    Write-Host "Error: .githooks\pre-commit not found" -ForegroundColor Red
+}

--- a/install-hooks.sh
+++ b/install-hooks.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Script to install Git hooks for all team members
+
+echo "🔧 Installing Git hooks..."
+
+# Check if we're in a Git repository
+if [ ! -d ".git" ]; then
+    echo "❌ Error: Not in a Git repository root"
+    exit 1
+fi
+
+# Create hooks directory if it doesn't exist
+mkdir -p .git/hooks
+
+# Copy hooks from .githooks to .git/hooks
+if [ -d ".githooks" ]; then
+    for hook in .githooks/*; do
+        if [ -f "$hook" ]; then
+            hook_name=$(basename "$hook")
+            cp "$hook" ".git/hooks/$hook_name"
+            chmod +x ".git/hooks/$hook_name"
+            echo "✅ Installed: $hook_name"
+        fi
+    done
+    echo "🎉 Git hooks installation complete!"
+    echo ""
+    echo "ℹ️  Hooks installed:"
+    ls -la .git/hooks/
+else
+    echo "❌ Error: .githooks directory not found"
+    exit 1
+fi


### PR DESCRIPTION
- Add .githooks/pre-commit to prevent direct commits to main branch
- Create install-hooks.sh for Unix/Linux/macOS installation
- Create install-hooks.ps1 for Windows PowerShell installation
- Add HOOKS.md documentation for team setup instructions
- Update README.md with quick start hook installation steps

This provides both local and shareable protection against direct main branch commits, working alongside GitHub branch protection rules for complete workflow safety.