### PR TITLE
Add Cursor Rules converted from Copilot instructions

### DIFF
--- a/.cursor/rules/00-repo-rules.mdc
+++ b/.cursor/rules/00-repo-rules.mdc
@@ -1,0 +1,52 @@
+---
+description: Repository-wide guidelines converted 1:1 from .github/copilot-instructions.md
+globs: **
+alwaysApply: true
+---
+
+## Copilot instructions (concise, repo-specific)
+
+Current state
+- Chat-first rewrite in progress (Step 0): `main.go` runs, TUI is being rebuilt. Core packages (`config/`, `auth/`, `appinsights/`, `logging/`) are active; many `tui/` files are placeholders. Read `docs/chat-first-ui-rewrite.md` before UI work.
+
+Do-first for agents
+- Always plan with the Todos tool; track each step separately.
+- Clean build gate: run `make all` (lint → race tests → build). Zero warnings, all tests green.
+- Research first: use Context7 + Perplexity + official Bubble Tea/Bubbles docs (and search charm repos) before changing linters, OAuth, or Bubble Tea patterns.
+- **CRITICAL: AI agents CANNOT run interactive TUI mode** - the app will hang waiting for keyboard input. Only use `./bc-insights-tui.exe -run=COMMAND` for testing. If interactive TUI testing is needed, ask the user to test it manually.
+
+Architecture (big picture)
+- Go + Charm ecosystem. Entry: `main.go` → init `logging` → load `config` → (future) start chat-first UI.
+- Dynamic telemetry: never hard-code Business Central log schemas. `eventId` defines `customDimensions` keys; table columns must follow KQL `project` results.
+- Packages:
+  - `config/`: precedence = defaults → JSON file (`config.json` or user home) → env (BCINSIGHTS_*) → flags. Provides `ValidateAndUpdateSetting`, `ListAllSettings` for `set/get` commands.
+  - `auth/`: Azure OAuth2 Device Flow. Key APIs: `InitiateDeviceFlow`, `PollForToken`, `SaveTokenSecurely` (go-keyring), `GetValidToken`/`RefreshTokenIfNeeded`.
+  - `appinsights/`: `ExecuteQuery(ctx, kql)` posts to `https://api.applicationinsights.io/v1/apps/{appId}/query`; returns tables with dynamic `Columns` and `Rows`. `ValidateQuery` does lightweight checks.
+  - `logging/`: logs to `logs/bc-insights-tui-YYYY-MM-DD.log`. Set `BC_INSIGHTS_LOG_LEVEL=DEBUG` to mirror to stdout.
+
+Workflows that matter
+- Build/test/lint: `make build`, `make test`, `make race`, `make lint`, `make all` (CI-equivalent). UI-specific targets: `make ui-test` (when UI exists).
+- Run (Windows): `./bc-insights-tui.exe`. It currently prints a Step 0 placeholder.
+- **Non-interactive mode: `./bc-insights-tui.exe -run=COMMAND` for testing/automation without TUI. Commands: `subs` (list subscriptions), `login` (device flow auth). MANDATORY for AI agents - never run interactive mode as it hangs waiting for keyboard input.**
+- Config examples (env): `LOG_FETCH_SIZE`, `BCINSIGHTS_ENVIRONMENT`, `BCINSIGHTS_APP_INSIGHTS_ID`, OAuth: `BCINSIGHTS_OAUTH2_TENANT_ID`, `BCINSIGHTS_OAUTH2_CLIENT_ID`, `BCINSIGHTS_OAUTH2_SCOPES`.
+
+UI conventions (chat-first)
+- Replace modal overlays/command palette with: top viewport (scrollback) + bottom textarea (chat). No layered modals; switch focus between components; Esc returns to chat. See `docs/chat-first-ui-rewrite.md` for layout, keys, and steps.
+- When reintroducing `tui/`, keep Bubble Tea MVC files: `model.go`, `update.go`, `view.go`. Compose bubbles; avoid global state.
+
+Project-specific rules
+- Errors must be actionable (include likely cause and next step, e.g., Azure portal link).
+- Online-only; no local caching. Low memory: summarize large results; open interactive tables on demand.
+- KQL-driven columns: parse API result columns; don’t rely on static structs.
+
+Integration quick path (example)
+1) Acquire token: `auth.NewAuthenticator(cfg.OAuth2)` → device flow → `SaveTokenSecurely`.
+2) Query: `appinsights.NewClient(token, cfg.ApplicationInsightsID).ExecuteQuery(ctx, kql)`.
+3) Render: build table columns from `QueryResponse.Tables[0].Columns`.
+
+Key files to read first
+- `docs/chat-first-ui-rewrite.md`, `makefile`, `config/config.go`, `auth/authenticator.go`, `appinsights/client.go`, `main.go`.
+
+Acceptance before PR
+- `make all` passes cleanly; style/lint zero warnings; tests (incl. race) pass. Update or add focused tests when changing public behavior.
+

--- a/.cursor/rules/10-go.mdc
+++ b/.cursor/rules/10-go.mdc
@@ -1,0 +1,294 @@
+---
+description: Instructions for writing Go code following idiomatic Go practices and community standards
+globs: **/*.go,**/go.mod,**/go.sum
+alwaysApply: false
+---
+
+# Go Development Instructions
+
+Follow idiomatic Go practices and community standards when writing Go code. These instructions are based on [Effective Go](https://go.dev/doc/effective_go), [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments), and [Google's Go Style Guide](https://google.github.io/styleguide/go/).
+
+## General Instructions
+
+- Write simple, clear, and idiomatic Go code
+- Favor clarity and simplicity over cleverness
+- Follow the principle of least surprise
+- Keep the happy path left-aligned (minimize indentation)
+- Return early to reduce nesting
+- Make the zero value useful
+- Document exported types, functions, methods, and packages
+- Use Go modules for dependency management
+
+## Naming Conventions
+
+### Packages
+
+- Use lowercase, single-word package names
+- Avoid underscores, hyphens, or mixedCaps
+- Choose names that describe what the package provides, not what it contains
+- Avoid generic names like `util`, `common`, or `base`
+- Package names should be singular, not plural
+
+### Variables and Functions
+
+- Use mixedCaps or MixedCaps (camelCase) rather than underscores
+- Keep names short but descriptive
+- Use single-letter variables only for very short scopes (like loop indices)
+- Exported names start with a capital letter
+- Unexported names start with a lowercase letter
+- Avoid stuttering (e.g., avoid `http.HTTPServer`, prefer `http.Server`)
+
+### Interfaces
+
+- Name interfaces with -er suffix when possible (e.g., `Reader`, `Writer`, `Formatter`)
+- Single-method interfaces should be named after the method (e.g., `Read` → `Reader`)
+- Keep interfaces small and focused
+
+### Constants
+
+- Use MixedCaps for exported constants
+- Use mixedCaps for unexported constants
+- Group related constants using `const` blocks
+- Consider using typed constants for better type safety
+
+## Code Style and Formatting
+
+### Formatting
+
+- Always use `gofmt` to format code
+- Use `goimports` to manage imports automatically
+- Keep line length reasonable (no hard limit, but consider readability)
+- Add blank lines to separate logical groups of code
+
+### Comments
+
+- Write comments in complete sentences
+- Start sentences with the name of the thing being described
+- Package comments should start with "Package [name]"
+- Use line comments (`//`) for most comments
+- Use block comments (`/* */`) sparingly, mainly for package documentation
+- Document why, not what, unless the what is complex
+
+### Error Handling
+
+- Check errors immediately after the function call
+- Don't ignore errors using `_` unless you have a good reason (document why)
+- Wrap errors with context using `fmt.Errorf` with `%w` verb
+- Create custom error types when you need to check for specific errors
+- Place error returns as the last return value
+- Name error variables `err`
+- Keep error messages lowercase and don't end with punctuation
+
+## Architecture and Project Structure
+
+### Package Organization
+
+- Follow standard Go project layout conventions
+- Keep `main` packages in `cmd/` directory
+- Put reusable packages in `pkg/` or `internal/`
+- Use `internal/` for packages that shouldn't be imported by external projects
+- Group related functionality into packages
+- Avoid circular dependencies
+
+### Dependency Management
+
+- Use Go modules (`go.mod` and `go.sum`)
+- Keep dependencies minimal
+- Regularly update dependencies for security patches
+- Use `go mod tidy` to clean up unused dependencies
+- Vendor dependencies only when necessary
+
+## Type Safety and Language Features
+
+### Type Definitions
+
+- Define types to add meaning and type safety
+- Use struct tags for JSON, XML, database mappings
+- Prefer explicit type conversions
+- Use type assertions carefully and check the second return value
+
+### Pointers vs Values
+
+- Use pointers for large structs or when you need to modify the receiver
+- Use values for small structs and when immutability is desired
+- Be consistent within a type's method set
+- Consider the zero value when choosing pointer vs value receivers
+
+### Interfaces and Composition
+
+- Accept interfaces, return concrete types
+- Keep interfaces small (1-3 methods is ideal)
+- Use embedding for composition
+- Define interfaces close to where they're used, not where they're implemented
+- Don't export interfaces unless necessary
+
+## Concurrency
+
+### Goroutines
+
+- Don't create goroutines in libraries; let the caller control concurrency
+- Always know how a goroutine will exit
+- Use `sync.WaitGroup` or channels to wait for goroutines
+- Avoid goroutine leaks by ensuring cleanup
+
+### Channels
+
+- Use channels to communicate between goroutines
+- Don't communicate by sharing memory; share memory by communicating
+- Close channels from the sender side, not the receiver
+- Use buffered channels when you know the capacity
+- Use `select` for non-blocking operations
+
+### Synchronization
+
+- Use `sync.Mutex` for protecting shared state
+- Keep critical sections small
+- Use `sync.RWMutex` when you have many readers
+- Prefer channels over mutexes when possible
+- Use `sync.Once` for one-time initialization
+
+## Error Handling Patterns
+
+### Creating Errors
+
+- Use `errors.New` for simple static errors
+- Use `fmt.Errorf` for dynamic errors
+- Create custom error types for domain-specific errors
+- Export error variables for sentinel errors
+- Use `errors.Is` and `errors.As` for error checking
+
+### Error Propagation
+
+- Add context when propagating errors up the stack
+- Don't log and return errors (choose one)
+- Handle errors at the appropriate level
+- Consider using structured errors for better debugging
+
+## API Design
+
+### HTTP Handlers
+
+- Use `http.HandlerFunc` for simple handlers
+- Implement `http.Handler` for handlers that need state
+- Use middleware for cross-cutting concerns
+- Set appropriate status codes and headers
+- Handle errors gracefully and return appropriate error responses
+
+### JSON APIs
+
+- Use struct tags to control JSON marshaling
+- Validate input data
+- Use pointers for optional fields
+- Consider using `json.RawMessage` for delayed parsing
+- Handle JSON errors appropriately
+
+## Performance Optimization
+
+### Memory Management
+
+- Minimize allocations in hot paths
+- Reuse objects when possible (consider `sync.Pool`)
+- Use value receivers for small structs
+- Preallocate slices when size is known
+- Avoid unnecessary string conversions
+
+### Profiling
+
+- Use built-in profiling tools (`pprof`)
+- Benchmark critical code paths
+- Profile before optimizing
+- Focus on algorithmic improvements first
+- Consider using `testing.B` for benchmarks
+
+## Testing
+
+### Test Organization
+
+- Keep tests in the same package (white-box testing)
+- Use `_test` package suffix for black-box testing
+- Name test files with `_test.go` suffix
+- Place test files next to the code they test
+
+### Writing Tests
+
+- Use table-driven tests for multiple test cases
+- Name tests descriptively using `Test_functionName_scenario`
+- Use subtests with `t.Run` for better organization
+- Test both success and error cases
+- Use `testify` or similar libraries sparingly
+
+### Test Helpers
+
+- Mark helper functions with `t.Helper()`
+- Create test fixtures for complex setup
+- Use `testing.TB` interface for functions used in tests and benchmarks
+- Clean up resources using `t.Cleanup()`
+
+## Security Best Practices
+
+### Input Validation
+
+- Validate all external input
+- Use strong typing to prevent invalid states
+- Sanitize data before using in SQL queries
+- Be careful with file paths from user input
+- Validate and escape data for different contexts (HTML, SQL, shell)
+
+### Cryptography
+
+- Use standard library crypto packages
+- Don't implement your own cryptography
+- Use crypto/rand for random number generation
+- Store passwords using bcrypt or similar
+- Use TLS for network communication
+
+## Documentation
+
+### Code Documentation
+
+- Document all exported symbols
+- Start documentation with the symbol name
+- Use examples in documentation when helpful
+- Keep documentation close to code
+- Update documentation when code changes
+
+### README and Documentation Files
+
+- Include clear setup instructions
+- Document dependencies and requirements
+- Provide usage examples
+- Document configuration options
+- Include troubleshooting section
+
+## Tools and Development Workflow
+
+### Essential Tools
+
+- `go fmt`: Format code
+- `go vet`: Find suspicious constructs
+- `golint` or `golangci-lint`: Additional linting
+- `go test`: Run tests
+- `go mod`: Manage dependencies
+- `go generate`: Code generation
+
+### Development Practices
+
+- Run tests before committing
+- Use pre-commit hooks for formatting and linting
+- Keep commits focused and atomic
+- Write meaningful commit messages
+- Review diffs before committing
+
+## Common Pitfalls to Avoid
+
+- Not checking errors
+- Ignoring race conditions
+- Creating goroutine leaks
+- Not using defer for cleanup
+- Modifying maps concurrently
+- Not understanding nil interfaces vs nil pointers
+- Forgetting to close resources (files, connections)
+- Using global variables unnecessarily
+- Over-using empty interfaces (`interface{}`)
+- Not considering the zero value of types
+

--- a/.cursor/rules/20-logging.mdc
+++ b/.cursor/rules/20-logging.mdc
@@ -1,0 +1,13 @@
+---
+description: Logging guidelines for debugging and application insights
+globs: **
+alwaysApply: false
+---
+When an error occurs in the application, it is important to log the error message along with any relevant context to aid in debugging.
+
+It is important that you make extensive use of the logging system to use this as a debugging tool and to gain insights into the application's behavior.
+When ever a configuration setting is changed, a log message should be generated to capture the old and new values.
+When ever a user action is taken that affects the state of the application, a log message should be generated to capture the details of the action.
+
+When you should fix an issue, make sure to read the most recent log file for insights into what went wrong.
+

--- a/.cursor/rules/30-research.mdc
+++ b/.cursor/rules/30-research.mdc
@@ -1,0 +1,15 @@
+---
+description: Research project context and coding guidelines
+globs: **
+alwaysApply: false
+---
+# Research Project Context and Coding Guidelines
+Always do proper research before starting any coding task. This includes understanding the problem.
+- use context7
+- perplexity
+- use the github tools to search code in the bubbles repo https://github.com/charmbracelet/bubbles
+- use the github tools to search code in the bubbletea repo https://pkg.go.dev/github.com/charmbracelet/bubbletea
+- use the github tools to search code in the reflow repo https://github.com/muesli/reflow for information on  ANSI-aware indenting and text wrapping
+- always read the documentation in the `docs/` directory
+Do your research as the first thing when starting a new task in your todo list.
+

--- a/.cursor/rules/40-todo.mdc
+++ b/.cursor/rules/40-todo.mdc
@@ -1,0 +1,12 @@
+---
+description: Todo list workflow guidelines
+globs: **
+alwaysApply: false
+---
+Always use a todo list to plan your work.
+
+- Break down tasks into smaller, manageable steps.
+- Make sure to always update tasks as you complete them.
+- After a task is completed, reevaluate your todo list, and adjust the todo list accordingly.
+- Always make sure to complete all tasks in your todo list.
+

--- a/.cursor/rules/50-ui.mdc
+++ b/.cursor/rules/50-ui.mdc
@@ -1,0 +1,10 @@
+---
+description: UI component styling guidelines for TUI
+globs: **
+alwaysApply: false
+---
+For all ui components, ensure consistent styling and make a modern design for a tui  app.
+write as little code as possible to achieve the desired functionality.
+stick strictly to the intention of the components used.
+if possible avoid manual calculating padding and margins, use the components to do that for you.
+


### PR DESCRIPTION
This PR converts GitHub Copilot instruction files to Cursor Rules in .cursor/rules.\n- 00-repo-rules.mdc (global)\n- 10-go.mdc\n- 20-logging.mdc\n- 30-research.mdc\n- 40-todo.mdc\n- 50-ui.mdc\n\nMapping: Copilot applyTo -> Cursor globs; description/alwaysApply set accordingly.