### PR TITLE
Feature/showcustomdimensionfields

### DIFF
--- a/appinsights/client.go
+++ b/appinsights/client.go
@@ -3,6 +3,7 @@ package appinsights
 // Application Insights API client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,12 +14,11 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/oauth2"
-
 	cfgpkg "github.com/FBakkensen/bc-insights-tui/config"
 	"github.com/FBakkensen/bc-insights-tui/debugdump"
 	util "github.com/FBakkensen/bc-insights-tui/internal/util"
 	"github.com/FBakkensen/bc-insights-tui/logging"
+	"golang.org/x/oauth2"
 )
 
 // Track last-seen raw capture settings to log changes once per process
@@ -43,6 +43,12 @@ type Client struct {
 	baseURL    string
 	auth       ApplicationInsightsAuthenticator
 	mu         sync.Mutex // Protects token field from concurrent access
+	// snapshot of relevant config to avoid reloading on every query
+	fetchLimit  int
+	rawEnabled  bool
+	rawPath     string
+	rawMaxBytes int
+	rawKeepN    int
 }
 
 // QueryRequest represents a KQL query request
@@ -70,27 +76,41 @@ type Column struct {
 
 // NewClient creates a new Application Insights client
 func NewClient(token *oauth2.Token, appID string) *Client {
+	cfg := cfgpkg.LoadConfigWithArgs(nil)
+	rawEnabled, resolvedPath, maxBytes := getRawCaptureConfigFrom(cfg)
 	return &Client{
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		token:   token,
-		appID:   appID,
-		baseURL: "https://api.applicationinsights.io",
+		token:       token,
+		appID:       appID,
+		baseURL:     "https://api.applicationinsights.io",
+		fetchLimit:  cfg.LogFetchSize,
+		rawEnabled:  rawEnabled,
+		rawPath:     resolvedPath,
+		rawMaxBytes: maxBytes,
+		rawKeepN:    cfg.DebugAppInsightsRawKeepN,
 	}
 }
 
 // NewClientWithAuthenticator creates a new Application Insights client that will automatically
 // acquire the proper Application Insights API token using the v1 endpoint
 func NewClientWithAuthenticator(authenticator ApplicationInsightsAuthenticator, appID string) *Client {
+	cfg := cfgpkg.LoadConfigWithArgs(nil)
+	rawEnabled, resolvedPath, maxBytes := getRawCaptureConfigFrom(cfg)
 	return &Client{
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		token:   nil, // Will be acquired on-demand
-		appID:   appID,
-		baseURL: "https://api.applicationinsights.io",
-		auth:    authenticator,
+		token:       nil, // Will be acquired on-demand
+		appID:       appID,
+		baseURL:     "https://api.applicationinsights.io",
+		auth:        authenticator,
+		fetchLimit:  cfg.LogFetchSize,
+		rawEnabled:  rawEnabled,
+		rawPath:     resolvedPath,
+		rawMaxBytes: maxBytes,
+		rawKeepN:    cfg.DebugAppInsightsRawKeepN,
 	}
 }
 
@@ -128,7 +148,7 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string) (*QueryResponse
 	)
 
 	// Create HTTP request
-	req, err := http.NewRequestWithContext(ctx, "POST", queryURL, strings.NewReader(string(bodyJSON)))
+	req, err := http.NewRequestWithContext(ctx, "POST", queryURL, bytes.NewReader(bodyJSON))
 	if err != nil {
 		logging.Error("KQL request creation failed", "error", err.Error())
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -138,13 +158,18 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string) (*QueryResponse
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
 
-	// Prepare optional raw debug capture
-	rawEnabled, resolvedPath, maxBytes := getRawCaptureConfig()
+	// Prepare optional raw debug capture (using snapshot)
+	rawEnabled := c.rawEnabled
+	resolvedPath := c.rawPath
+	maxBytes := c.rawMaxBytes
 	checkAndLogRawConfigChange(rawEnabled, resolvedPath, maxBytes)
 
 	// If enabled, write request-only capture first
 	if rawEnabled {
-		writeRawRequestCapture(req, bodyJSON, maxBytes, resolvedPath)
+		startedAt := debugdump.Now()
+		writeRawRequestCapture(req, bodyJSON, maxBytes, resolvedPath, startedAt)
+		// Store startedAt in request context for later completion capture
+		ctx = context.WithValue(ctx, ctxKeyStartedAt{}, startedAt)
 	}
 
 	// Execute request
@@ -160,7 +185,8 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string) (*QueryResponse
 		logging.Error("KQL request failed", "error", err.Error(), "ctxErr", sel)
 		// Write error-only capture if enabled
 		if rawEnabled {
-			writeRawTransportError(req, bodyJSON, maxBytes, resolvedPath, err, time.Since(start))
+			startedAt, _ := ctx.Value(ctxKeyStartedAt{}).(string)
+			writeRawTransportError(req, bodyJSON, maxBytes, resolvedPath, err, time.Since(start), startedAt, c.rawKeepN)
 		}
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
@@ -188,7 +214,8 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string) (*QueryResponse
 		)
 		// Write full capture if enabled
 		if rawEnabled {
-			writeRawHTTPResult(req, bodyJSON, resp, body, maxBytes, resolvedPath, dur, fmt.Sprintf("API request failed with status %d", resp.StatusCode))
+			startedAt, _ := ctx.Value(ctxKeyStartedAt{}).(string)
+			writeRawHTTPResult(req, bodyJSON, resp, body, maxBytes, resolvedPath, dur, fmt.Sprintf("API request failed with status %d", resp.StatusCode), startedAt, c.rawKeepN)
 		}
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
@@ -222,7 +249,8 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string) (*QueryResponse
 
 	// Write success capture if enabled
 	if rawEnabled {
-		writeRawHTTPResult(req, bodyJSON, resp, body, maxBytes, resolvedPath, dur, "")
+		startedAt, _ := ctx.Value(ctxKeyStartedAt{}).(string)
+		writeRawHTTPResult(req, bodyJSON, resp, body, maxBytes, resolvedPath, dur, "", startedAt, c.rawKeepN)
 	}
 
 	return &queryResp, nil
@@ -298,17 +326,16 @@ func startsWithKnownTable(stmt string) bool {
 
 // maybeApplyFetchLimit loads config and applies fetch limit if appropriate. It logs a concise decision.
 func (c *Client) maybeApplyFetchLimit(query string) string {
-	cfg := cfgpkg.LoadConfigWithArgs(nil)
-	if cfg.LogFetchSize <= 0 {
-		logging.Debug("KQL fetch limit not applied", "reason", "fetch_zero", "limit", fmt.Sprintf("%d", cfg.LogFetchSize))
+	if c.fetchLimit <= 0 {
+		logging.Debug("KQL fetch limit not applied", "reason", "fetch_zero", "limit", fmt.Sprintf("%d", c.fetchLimit))
 		return query
 	}
-	mutated, applied, reason := applyFetchLimitIfNeeded(query, cfg.LogFetchSize)
+	mutated, applied, reason := applyFetchLimitIfNeeded(query, c.fetchLimit)
 	if applied {
-		logging.Debug("KQL fetch limit applied", "limit", fmt.Sprintf("%d", cfg.LogFetchSize), "reason", reason)
+		logging.Debug("KQL fetch limit applied", "limit", fmt.Sprintf("%d", c.fetchLimit), "reason", reason)
 		return mutated
 	}
-	logging.Debug("KQL fetch limit not applied", "reason", reason, "limit", fmt.Sprintf("%d", cfg.LogFetchSize))
+	logging.Debug("KQL fetch limit not applied", "reason", reason, "limit", fmt.Sprintf("%d", c.fetchLimit))
 	return query
 }
 
@@ -320,9 +347,8 @@ func computeDeadlineFields(ctx context.Context) (string, string) {
 	return "false", ""
 }
 
-// getRawCaptureConfig reads config/env to determine raw capture enablement and resolves path.
-func getRawCaptureConfig() (bool, string, int) {
-	cfg := cfgpkg.LoadConfigWithArgs(nil)
+// getRawCaptureConfigFrom resolves raw capture config from a given config snapshot.
+func getRawCaptureConfigFrom(cfg cfgpkg.Config) (bool, string, int) {
 	if !cfg.DebugAppInsightsRawEnable {
 		return false, "", cfg.DebugAppInsightsRawMaxBytes
 	}
@@ -375,7 +401,7 @@ func checkAndLogRawConfigChange(enabled bool, path string, maxBytes int) {
 }
 
 // writeRawRequestCapture writes the initial request-only capture and logs a start event.
-func writeRawRequestCapture(req *http.Request, bodyJSON []byte, maxBytes int, path string) {
+func writeRawRequestCapture(req *http.Request, bodyJSON []byte, maxBytes int, path, startedAt string) {
 	hdrs := map[string]string{
 		"content-type":  req.Header.Get("Content-Type"),
 		"authorization": req.Header.Get("Authorization"),
@@ -387,7 +413,7 @@ func writeRawRequestCapture(req *http.Request, bodyJSON []byte, maxBytes int, pa
 		Version:    1,
 		CapturedAt: debugdump.Now(),
 		Request: debugdump.AIRawRequest{
-			StartedAt: debugdump.Now(),
+			StartedAt: startedAt,
 			Method:    req.Method,
 			URL:       req.URL.String(),
 			Headers:   red,
@@ -402,11 +428,11 @@ func writeRawRequestCapture(req *http.Request, bodyJSON []byte, maxBytes int, pa
 		logging.Warn("AI raw dump request write failed", "error", werr.Error())
 		return
 	}
-	logging.Info("ai_raw_dump_started", "path", path, "body_bytes", fmt.Sprintf("%d", bodyLen))
+	logging.Debug("ai_raw_dump_started", "path", path, "body_bytes", fmt.Sprintf("%d", bodyLen))
 }
 
 // writeRawTransportError writes a full capture with request details and error message.
-func writeRawTransportError(req *http.Request, bodyJSON []byte, maxBytes int, path string, err error, dur time.Duration) {
+func writeRawTransportError(req *http.Request, bodyJSON []byte, maxBytes int, path string, err error, dur time.Duration, startedAt string, keepN int) {
 	reqHdr := debugdump.RedactHeaders(map[string]string{
 		"content-type":  req.Header.Get("Content-Type"),
 		"authorization": req.Header.Get("Authorization"),
@@ -416,7 +442,7 @@ func writeRawTransportError(req *http.Request, bodyJSON []byte, maxBytes int, pa
 		Version:    1,
 		CapturedAt: debugdump.Now(),
 		Request: debugdump.AIRawRequest{
-			StartedAt: "",
+			StartedAt: startedAt,
 			Method:    req.Method,
 			URL:       req.URL.String(),
 			Headers:   reqHdr,
@@ -427,15 +453,18 @@ func writeRawTransportError(req *http.Request, bodyJSON []byte, maxBytes int, pa
 		Response: nil,
 		Error:    &debugdump.AIRawError{Message: err.Error()},
 	}
+	if keepN > 0 {
+		_ = debugdump.WriteAIRawFullRotating(path, keepN, cap)
+	}
 	if werr := debugdump.WriteAIRawFull(path, cap); werr != nil {
 		logging.Warn("AI raw dump error write failed", "error", werr.Error())
 		return
 	}
-	logging.Info("ai_raw_dump_written", "path", path, "status", "n/a", "duration_ms", fmt.Sprintf("%d", dur.Milliseconds()), "resp_bytes", "0")
+	logging.Debug("ai_raw_dump_written", "path", path, "status", "n/a", "duration_ms", fmt.Sprintf("%d", dur.Milliseconds()), "resp_bytes", "0")
 }
 
 // writeRawHTTPResult writes a full capture for HTTP responses, optionally including an error message.
-func writeRawHTTPResult(req *http.Request, bodyJSON []byte, resp *http.Response, respBody []byte, maxBytes int, path string, dur time.Duration, errMsg string) {
+func writeRawHTTPResult(req *http.Request, bodyJSON []byte, resp *http.Response, respBody []byte, maxBytes int, path string, dur time.Duration, errMsg, startedAt string, keepN int) {
 	rh := map[string]string{
 		"x-ms-request-id":             resp.Header.Get("x-ms-request-id"),
 		"x-ms-correlation-request-id": resp.Header.Get("x-ms-correlation-request-id"),
@@ -450,7 +479,7 @@ func writeRawHTTPResult(req *http.Request, bodyJSON []byte, resp *http.Response,
 		Version:    1,
 		CapturedAt: debugdump.Now(),
 		Request: debugdump.AIRawRequest{
-			StartedAt: "",
+			StartedAt: startedAt,
 			Method:    req.Method,
 			URL:       req.URL.String(),
 			Headers:   debugdump.RedactHeaders(map[string]string{"content-type": req.Header.Get("Content-Type"), "authorization": req.Header.Get("Authorization")}),
@@ -471,12 +500,18 @@ func writeRawHTTPResult(req *http.Request, bodyJSON []byte, resp *http.Response,
 	if strings.TrimSpace(errMsg) != "" {
 		full.Error = &debugdump.AIRawError{Message: errMsg}
 	}
+	if keepN > 0 {
+		_ = debugdump.WriteAIRawFullRotating(path, keepN, full)
+	}
 	if werr := debugdump.WriteAIRawFull(path, full); werr != nil {
 		logging.Warn("AI raw dump full write failed", "error", werr.Error())
 		return
 	}
-	logging.Info("ai_raw_dump_written", "path", path, "status", fmt.Sprintf("%d", resp.StatusCode), "duration_ms", fmt.Sprintf("%d", dur.Milliseconds()), "resp_bytes", fmt.Sprintf("%d", bodyLen))
+	logging.Debug("ai_raw_dump_written", "path", path, "status", fmt.Sprintf("%d", resp.StatusCode), "duration_ms", fmt.Sprintf("%d", dur.Milliseconds()), "resp_bytes", fmt.Sprintf("%d", bodyLen))
 }
+
+// ctxKeyStartedAt is an unexported key type for context values
+type ctxKeyStartedAt struct{}
 
 // getValidToken returns a valid token, acquiring one via authenticator if needed
 func (c *Client) getValidToken(ctx context.Context) (*oauth2.Token, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,7 @@ type Config struct {
 	DebugAppInsightsRawEnable   bool   `json:"debug.appInsightsRawEnable" yaml:"debug.appInsightsRawEnable"`
 	DebugAppInsightsRawFile     string `json:"debug.appInsightsRawFile" yaml:"debug.appInsightsRawFile"`
 	DebugAppInsightsRawMaxBytes int    `json:"debug.appInsightsRawMaxBytes" yaml:"debug.appInsightsRawMaxBytes"`
+	DebugAppInsightsRawKeepN    int    `json:"debug.appInsightsRawKeepN" yaml:"debug.appInsightsRawKeepN"`
 }
 
 // NewConfig creates a new Config with default values and initialized mutex
@@ -97,6 +98,7 @@ func NewConfig() Config {
 		DebugAppInsightsRawEnable:   false,
 		DebugAppInsightsRawFile:     "logs/appinsights-raw.yaml",
 		DebugAppInsightsRawMaxBytes: 1048576,
+		DebugAppInsightsRawKeepN:    5,
 	}
 }
 
@@ -205,6 +207,11 @@ func applyAIRawDebugEnvVars(cfg *Config) {
 			cfg.DebugAppInsightsRawMaxBytes = parsed
 		}
 	}
+	if v, ok := os.LookupEnv("BCINSIGHTS_AI_RAW_KEEP_N"); ok {
+		if parsed, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && parsed >= 0 {
+			cfg.DebugAppInsightsRawKeepN = parsed
+		}
+	}
 }
 
 // mergeConfig merges file configuration into the base config.
@@ -271,6 +278,9 @@ func mergeAIRawDebug(base, file *Config) {
 	if file.DebugAppInsightsRawMaxBytes >= 0 {
 		// Accept 0 (unlimited) and positive
 		base.DebugAppInsightsRawMaxBytes = file.DebugAppInsightsRawMaxBytes
+	}
+	if file.DebugAppInsightsRawKeepN >= 0 {
+		base.DebugAppInsightsRawKeepN = file.DebugAppInsightsRawKeepN
 	}
 }
 
@@ -599,6 +609,7 @@ func (c *Config) ListAllSettings() map[string]string {
 		settings["debug.appInsightsRawFile"] = c.DebugAppInsightsRawFile
 	}
 	settings["debug.appInsightsRawMaxBytes"] = strconv.Itoa(c.DebugAppInsightsRawMaxBytes)
+	settings["debug.appInsightsRawKeepN"] = strconv.Itoa(c.DebugAppInsightsRawKeepN)
 
 	return settings
 }

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -417,8 +417,8 @@ func TestListAllSettings(t *testing.T) {
 	}
 
 	// Check that the total count matches expected with debug settings included
-	if len(settings) != 15 {
-		t.Errorf("Expected exactly 15 settings, got %d: %v", len(settings), settings)
+	if len(settings) != 16 {
+		t.Errorf("Expected exactly 16 settings, got %d: %v", len(settings), settings)
 	}
 }
 

--- a/debugdump/ai_raw_rotation_test.go
+++ b/debugdump/ai_raw_rotation_test.go
@@ -1,0 +1,38 @@
+package debugdump
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteAIRawFullRotating_PrunesOld(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "appinsights-raw.yaml")
+	cap := AIRawCapture{Version: 1}
+
+	// Write 7 captures with keepN=5
+	for i := 0; i < 7; i++ {
+		if err := WriteAIRawFullRotating(base, 5, cap); err != nil {
+			t.Fatalf("rotating write %d: %v", i, err)
+		}
+	}
+	// Count rotated files
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	cnt := 0
+	for _, e := range entries {
+		name := e.Name()
+		if name == "appinsights-raw.yaml" {
+			continue // main file not created by rotating
+		}
+		if filepath.Ext(name) == ".yaml" && len(name) > len("appinsights-raw-"+".yaml") && name[:len("appinsights-raw-")] == "appinsights-raw-" {
+			cnt++
+		}
+	}
+	if cnt != 5 {
+		t.Fatalf("expected 5 rotated files, got %d (entries=%v)", cnt, entries)
+	}
+}

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -35,14 +35,14 @@ The application will run on Windows, feature a low memory footprint, and provide
 
 ## 4. Core Concepts: Business Central Telemetry
 
-A key aspect of Business Central logging is its dynamic and structured nature within Application Insights. Understanding this is crucial for the design of this tool.
+Business Central telemetry in Application Insights is highly dynamic. For our purposes, we treat it as schemaless at the UI layer and render what the service returns without requiring predefined shapes.
 
 * **Primary Data Source:** Most log data is stored in the `traces` table.
-* **The `customDimensions` Field:** While standard columns exist, the most valuable, context-rich information for a log entry is stored in the `customDimensions` field. This field is a flexible key-value store.
-* **The `eventId` as a Schema Definer:** The structure of the data within `customDimensions` is determined by the `eventId`. Each `eventId` represents a specific type of event (e.g., a database lock, a web service call) and has its own unique set of fields within `customDimensions`.
-* **Dynamic and Extensible:** The list of `eventId`s and their corresponding schemas is not fixed. Microsoft adds new events with major releases, and partners can define their own custom events.
+* **The `customDimensions` Field:** While standard columns exist, the most valuable, context-rich information for a log entry is stored in the `customDimensions` field, which is a flexible key-value store. Keys and values can vary by event and over time.
+* **No hard-coded schemas:** We do not infer or enforce per-event schemas (e.g., by `eventId`). Instead, we display the timestamp directly from the row and show all key-value pairs under `customDimensions` as-is.
+* **Dynamic and Extensible:** The set of keys present in `customDimensions` changes across versions and partners. The tool adapts by discovering and rendering these keys dynamically.
 
-This means **bc-insights-tui cannot rely on a static data model**. It must be architected to first read the `eventId` and then dynamically parse and display the associated key-value pairs from `customDimensions`.
+Implication: **bc-insights-tui avoids static models**. The details view reads the row timestamp and renders all fields found in `customDimensions`, sorted and formatted for readability, without relying on `eventId`-driven structure.
 
 ---
 
@@ -106,9 +106,10 @@ Development will proceed in phases to ensure a solid foundation and iterative pr
     * [x] Create the `appinsights` client to make authenticated API calls.
     * [x] Implement a function to execute a basic KQL query that respects the configured fetch size.
     * [x] Create a view to display a list of log entries with default columns.
-    * [ ] **Implement dynamic parsing of `customDimensions` based on `eventId` for the details view.**
+    * [ ] **Implement details view that shows the row timestamp and all fields from `customDimensions` (no per-`eventId` schema).**
     * [ ] Implement pagination logic to "load more" logs.
     * [ ] **Handle API errors and loading states with clear, guiding messages.**
+    * [ ] Implement a great visual way to display the result table, that allows horizontal scrolling, dynamics width of columns, and fit inside the general width and height of the ui.
 * **Phase 4: Advanced Features**
     * [ ] Implement a detailed view for a single log entry.
     * [ ] **Implement a KQL editor for writing and editing custom queries.**

--- a/docs/specs/step-10-dynamic-column-ranking.md
+++ b/docs/specs/step-10-dynamic-column-ranking.md
@@ -1,0 +1,149 @@
+# Step 10 — Dynamic Column Ranking (SDD)
+
+Status: Draft
+Owner: TUI Team
+Last updated: 2025-08-10
+
+## Summary
+
+Rank dynamic columns (customDimensions) for list views so that important fields appear first. Keep timestamp and message as primaries, then order remaining keys using frequency and keyword signals. Maintain one canonical header set (no duplicates) shared by snapshot and interactive views, with consistent ellipsis (+N) semantics.
+
+## Goals
+
+- Fixed primaries first: `timestamp`, `message`.
+- Consolidated dynamic headers: case-insensitive union of customDimensions keys; no duplicates.
+- Order custom keys by data-driven signals: frequency, keywords, with stable tie breakers.
+- Deterministic and cheap to compute on a bounded sample (first N rows).
+- Identical ordering across snapshot and interactive table views.
+- Clear instrumentation for diagnostics; no secrets logged.
+
+## Non-Goals
+
+- Query-aware boosts (e.g., from KQL project/extend/rename) — future step.
+- Full user pinning UI — may be introduced later; basic hooks included here.
+
+## User Story
+
+As a user, when I run a query that returns many dynamic fields, the most useful columns (IDs, error/status, durations) should appear first so I can scan results without horizontal scrolling. The same order should apply in both the snapshot and interactive views.
+
+## Terminology
+
+- Canonical headers: `timestamp`, `message`, plus custom keys discovered across all rows (case-insensitive de-dup, first-seen casing), sorted by ranking; used by both list views.
+- Sample window: first N rows (default 200) used to compute ranking metrics.
+
+## Ranking Model
+
+Score components (tunable weights):
+
+- presenceRate (strong): fraction of sampled rows where key is non-empty. Weight: 5.0
+- keywordBoost (moderate): sum of matched regex boosts. Weight: as listed below.
+- variability (moderate): normalized distinct value count in sample. Weight: 2.0
+- lenPenalty (moderate): normalized average value length penalty (longer = lower). Weight: -1.0
+- typeBias (light): small boosts for boolean/short categorical fields; small penalty for long strings. Weight: 0.5
+
+Overall score example:
+
+score = 5·presenceRate + 2·variability + keywordBoost − 1·lenPenalty + 0.5·typeBias
+
+Tie-breakers: pinned > keyword match count > presenceRate > variability > shorter avgLen > case-insensitive alpha.
+
+### Primaries and Known-Good Keys
+
+- Always first: `timestamp`, `message`.
+- Known-good keys (optional small set): `requestId`, `operationId`, `correlationId`, `traceId`, `spanId`, `userId`, `sessionId`, `severity`, `category`, `environment`, `tenantId`, `companyId`, `status`, `resultCode`, `durationMs`.
+- Placement: Known-good keys are boosted by keyword rules and/or a small hard offset so they rise naturally without absolute pinning.
+
+### Keyword Rules (default)
+
+Regex patterns (case-insensitive), with additive boosts:
+
+- `(?i)^(request|operation|correlation|trace|span).*` → +3
+- `(?i).*(status|result|outcome).*` → +2
+- `(?i).*(error|exception|severity).*` → +3
+- `(?i).*(duration|latency|elapsed).*` → +2
+- `(?i).*(user|session|tenant|company|environment).*` → +2
+- `(?i).*(id)$` → +2 (generic ID suffix)
+
+### Sampling and Metrics
+
+Compute metrics over first N rows (configurable, default 200):
+
+- presenceRate: non-empty count / sample size
+- variability: min(1, distinctCount / distinctCap), with distinctCap default 50
+- avgLen: sum(len(value)) / occurrences, normalized by a cap (e.g., 200 chars)
+- typeBias: +0.2 for boolean, +0.2 for short-enum-like fields (<= 5 distinct values and avgLen <= 12); −0.2 for very long strings (avgLen >= 120)
+
+Normalization caps are configuration knobs to keep calculations bounded.
+
+## Algorithm
+
+1. Discover canonical headers: `timestamp`, `message`, then case-insensitive union of custom keys across all rows; de-duplicate; preserve first-seen casing.
+2. Take sample window of up to N rows.
+3. For each custom key, compute metrics and score.
+4. Sort custom keys by score desc; apply tie-breakers.
+5. Final header order: primaries → ranked custom keys.
+6. Use the same headers in both snapshot and interactive; ellipsis (+N) continues to reflect hidden header count.
+
+## Configuration
+
+Environment variables and config settings (optional, with defaults):
+
+- BCINSIGHTS_RANK_SAMPLE_SIZE (int, default 200)
+- BCINSIGHTS_RANK_DISTINCT_CAP (int, default 50)
+- BCINSIGHTS_RANK_LEN_CAP (int, default 200)
+- BCINSIGHTS_RANK_WEIGHT_PRESENCE (float, default 5.0)
+- BCINSIGHTS_RANK_WEIGHT_VARIABILITY (float, default 2.0)
+- BCINSIGHTS_RANK_WEIGHT_KEYWORD (float, implicit via regex boosts)
+- BCINSIGHTS_RANK_WEIGHT_LEN_PENALTY (float, default -1.0)
+- BCINSIGHTS_RANK_WEIGHT_TYPE (float, default 0.5)
+- BCINSIGHTS_RANK_REGEX (string, optional; JSON or semicolon spec for custom regex→boost rules)
+- BCINSIGHTS_RANK_PINNED (string, optional; comma-separated keys to pin first after primaries)
+
+Defaults should be hard-coded with config overrides via existing precedence (defaults → file → env → flags).
+
+## Telemetry & Logging
+
+- On result processing, log:
+  - canonical header count and a few example keys.
+  - sample size used, total keys, and top 10 ranked keys with components (presence, variability, avgLen, keyword matches, final score).
+- Never log values or queries; only counts and key names.
+
+## Acceptance Criteria
+
+- Timestamp and message are always first.
+- Consolidated headers are a case-insensitive superset of details (no duplicates).
+- With ranking enabled, keys with higher presence and relevant keywords appear before sparse/long blob-like keys.
+- Snapshot and interactive list show the same header order and ellipsis count.
+- Ranking computation runs within 30ms on typical datasets (<= 200 rows, <= 200 keys); measured locally.
+- Logging provides enough context to debug ranking without exposing sensitive data.
+
+## Test Plan
+
+Unit tests (ranker):
+- Presence dominance: a key present in 90% rows ranks above one in 10%.
+- Keyword influence: `errorCount` outranks a similarly dense non-keyword key.
+- Length penalty: a long text field demoted below a compact ID.
+- Variability boost: categorical fields with multiple distinct values outrank constants.
+- Case-insensitive de-dup: `Foo`, `foo`, `FOO` merge to one header; values map regardless of case.
+- Determinism: same inputs → same order; stable sort under ties.
+
+UI tests:
+- Header order matches ranker output (verify first few columns).
+- Ellipsis (+N) computed over the full canonical set; hidden columns are the lowest-ranked.
+
+## Rollout & Feature Flags
+
+- Introduce a config flag `BCINSIGHTS_RANK_ENABLE` (default true). Allow disabling for troubleshooting.
+- Guard complex regex parsing behind defensive error handling; fallback to frequency-only ranking if regex parsing fails.
+
+## Risks & Mitigations
+
+- Wide schemas may be slow: cap sample and use O(1) capped structures (distinct sets, length caps).
+- Overfitting to keyword rules: keep weights moderate; allow configuration.
+- User confusion: document that ranking is automatic; allow pinning and alternative sort modes in future iterations.
+
+## Future Work
+
+- Query-aware ranking: boost keys projected/extended in the KQL.
+- User pin/unpin and sort mode cycling from the UI.
+- Persist learned weights per appId/query hash to personalize ordering over time.

--- a/docs/specs/step-9-dynamic-customdimensions-details.md
+++ b/docs/specs/step-9-dynamic-customdimensions-details.md
@@ -1,0 +1,176 @@
+# Step 9 — Dynamic customDimensions Details View (Spec-Driven)
+
+This document specifies the details view that renders the Business Central `customDimensions` payload per log row without any per-`eventId` schema. The goal is to provide a simple, complete, and safe presentation of the timestamp and all `customDimensions` fields.
+
+## Purpose and scope
+
+- Provide an interactive details panel for a selected result row that:
+  - Shows the row timestamp directly from the `traces` table (from the `timestamp` column when present; fall back to common variants like `timeGenerated` if available).
+  - Lists all fields from `customDimensions` dynamically (no static models and no per-`eventId` schema).
+  - Avoids additional top-level fields unless explicitly added later; the v1 scope is timestamp + all `customDimensions`.
+- Keep the UI responsive and simple; avoid bespoke layout math—prefer Bubbles components with natural wrapping.
+- Do not change query behavior; details view operates on the existing result row in memory.
+
+Non-goals (deferred):
+- Persisted “details history”.
+- Custom per-event layouts (e.g., bespoke cards). The initial version uses generic, heuristic ordering.
+- In-row JSON editing or re-querying from details.
+
+## Dependencies and references
+
+- Data: `appinsights.QueryResponse` → `Tables[...].Columns` + `Rows` (existing).
+- UI: `tui/` Bubble Tea MVC. Table view already shows query results; details will open from table selection.
+- Guidelines: `.github/copilot-instructions.md` (dynamic telemetry, never hard-code schemas), `docs/overview.md` (Business Central context), `.github/instructions/ui.instructions.md` (minimal code, consistent styling), `.github/instructions/logging.instructions.md` (log important user actions; no secrets).
+
+## Requirements (contract)
+
+Functional
+- Open details from the interactive results table with Enter; close with Esc.
+- Details panel shows:
+  - Header: table name, row index, and a short summary (presence of timestamp and count of custom fields).
+  - Timestamp line: value from `timestamp` (or `timeGenerated`) when present.
+  - “customDimensions” section: dynamic key/value list containing all keys from the row’s `customDimensions` value.
+- Dynamic parsing rules for `customDimensions`:
+  - Accept underlying types: map/object, JSON string, or null.
+  - When a string, attempt JSON parse; if parse fails, render the raw string under a single key (e.g., `raw`).
+  - Normalize to a flat map of keys → string values:
+    - For scalar values, stringify (numbers, bools, strings, null → empty).
+    - For nested objects/arrays, flatten up to depth=2 using dot notation (e.g., `parent.child`), and stringify deeper structures as minified JSON.
+- Ordering & grouping:
+  - customDimensions: present all keys and sort A→Z (case-insensitive). No per-`eventId` prioritization.
+- Rendering:
+  - Use a viewport-based text rendering with wrapping. Each field on its own line as `key: value`.
+  - Long values (e.g., URLs, JSON) are wrapped; consider truncating lines after a safe width in snapshot, but details should allow scrolling.
+- Logging:
+  - On open: `details_opened` with `table`, `row_index`, `has_timestamp`, and `custom_count`.
+  - On close: `details_closed` with `duration_ms` spent in view.
+  - Never log raw `customDimensions` values.
+
+Error handling & edge cases
+- If `customDimensions` is missing or null: show “customDimensions: <none>”.
+- If `customDimensions` cannot be parsed: show raw string with a parse warning line.
+- Handle rows where `customDimensions` was projected away by KQL: show timestamp if present and indicate `<none>` for `customDimensions`.
+- Handle unknown or new event IDs transparently with the same generic renderer.
+
+Performance & lifecycle
+- Parsing happens only when opening details, against the single selected row.
+- No background I/O; all in-memory.
+- Memory impact is minimal; flattening is bounded to depth 2 and only runs for one row at a time.
+
+Security & privacy
+- Do not log raw bodies, `customDimensions` content, or tokens.
+- Redaction: No additional redaction beyond what queries already avoid; details are for local display. If future redaction is needed, add a key-based redaction list.
+
+## Config and UX
+
+- No new settings in v1. Details view is triggered by user action and reads from existing results state.
+- Future (deferred): a config to control flatten-depth or maximum value length.
+
+## Data contracts
+
+Input
+- Columns: `[]appinsights.Column` (name, type)
+- Row: `[]interface{}` (same order/length as Columns; element types may be string, float64, bool, nil, map[string]any, []any)
+
+Output (normalized for view)
+- Metadata: `table` (string), `rowIndex` (int)
+- Timestamp: `timestamp` (string; empty when not present)
+- Custom dims: ordered `[]DetailField`
+
+DetailField
+- key: string
+- value: string (human-friendly; JSON minified when necessary)
+- group: enum {Standard, Custom}
+- priority: int (lower renders first; used only within Custom group)
+
+Helper function contract (non-UI)
+- Build function in a new internal helper package to keep UI thin:
+  - `internal/telemetry/details.go`
+  - `func BuildDetails(columns []appinsights.Column, row []interface{}) (timestamp string, custom []DetailField)`
+  - Behavior per rules above (parse, flatten, order, stringify).
+  - No logging from the helper; logging is done at UI open/close points.
+
+## Algorithms
+
+1) Locate columns by name (case-insensitive): indices for `customDimensions`, `timestamp` (fallback: `timeGenerated`).
+2) Parse `customDimensions` value from row:
+   - If value is `map[string]any`, use it.
+   - Else if `string`, try `json.Unmarshal` to `any`. If object/array → use; else treat as raw string.
+   - Else if `[]any`, flatten indices as `key[index]` or stringify JSON.
+   - Else nil → none.
+3) customDimensions fields: flatten depth ≤ 2; sort by key A→Z (case-insensitive); stringify values.
+4) Return `(timestamp, custom)` to UI.
+
+Stringify rules
+- nil → ""
+- bool/number → fmt-based string
+- string → as-is
+- map/array → minified JSON (compact) unless included via a flattened key at depth ≤ 2
+
+## UI integration
+
+- Trigger: In table results mode, pressing Enter on a selected row opens details.
+- Layout: Reuse a `viewport.Model` sized like the results view; a simple header (table, row index, counts) followed by:
+  - Timestamp line if present
+  - “customDimensions” (key: value for all keys)
+- Keys: Esc closes details and returns to table. Future: `/` to filter within details (deferred).
+- Keep the design minimal and consistent per UI instructions; rely on Bubbles wrapping.
+
+## Logging
+
+- On open: `logging.Info("details_opened", "table", t, "row_index", i, "has_timestamp", ts != "", "custom_count", len(custom))`
+- On close: `logging.Info("details_closed", "duration_ms", dur)`
+
+## Tests
+
+Unit (helper)
+- Location: `internal/telemetry/details_test.go`
+- Cases:
+  - customDimensions as map[string]any → flatten and list all keys.
+  - customDimensions as JSON string → parses to map and works as above.
+  - No customDimensions column → timestamp-only (if present) and `<none>` for custom.
+  - customDimensions parse error (invalid JSON string) → raw shown with parse warning marker.
+  - Nested objects/arrays → flattened to depth 2; deeper structures stringified; arrays rendered with indices or JSON.
+  - Mixed types (numbers, bools, null) → stringified correctly.
+
+UI (lightweight)
+- Location: `tui/` tests (new tests or extend existing patterns):
+  - Simulate results present and Enter in table mode → details opens; Esc closes.
+  - Snapshot of rendered details contains header and expected key lines.
+
+## Acceptance criteria
+
+- Selecting a row and pressing Enter opens a details panel showing the timestamp (if present) and all `customDimensions` fields parsed dynamically.
+- No hard-coded schemas or `eventId`-based prioritization are required; unknown event IDs display cleanly as part of `customDimensions`.
+- Logs include `details_opened`/`details_closed` without leaking field values.
+- Unit tests cover parsing for both map and string `customDimensions` with nested content.
+
+## Implementation plan (phased)
+
+1) Helper package
+- Create `internal/telemetry/details.go` with `DetailField` and `BuildDetails` implementation.
+- Add focused unit tests in `internal/telemetry/details_test.go`.
+
+2) TUI integration (minimal)
+- In table mode, handle Enter to open a new `modeDetails` (new enum) using a `viewport.Model`.
+- Build content string using helper output; header + sections; set viewport with wrapping.
+- Esc returns to table mode.
+
+3) Logging
+- Add `details_opened` and `details_closed` logs at the UI layer.
+
+4) Polishing (optional, small)
+- Pretty JSON minifier and safe truncation for extremely long values (only in UI rendering, not in helper normalization).
+- Simple in-view search (`/` to filter) can be deferred.
+
+5) Docs
+- Update README usage notes under results table to mention Enter opens details.
+
+Out of scope for this step
+- Saved schemas or per-event custom templates.
+- Clipboard integration and advanced filtering.
+- Config flags for depth/length.
+
+Notes
+- BC telemetry evolves; the generic renderer must remain robust to new keys.
+- Keep UI lean; most complexity remains in the parsing helper with focused tests.

--- a/internal/telemetry/details.go
+++ b/internal/telemetry/details.go
@@ -1,0 +1,209 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/FBakkensen/bc-insights-tui/appinsights"
+)
+
+// Group represents a display group for detail fields.
+type Group int
+
+const (
+	GroupStandard Group = iota
+	GroupCustom
+)
+
+// DetailField represents a normalized key/value for display.
+type DetailField struct {
+	Key      string
+	Value    string
+	Group    Group
+	Priority int // lower renders first
+}
+
+// BuildDetails extracts a timestamp and normalized customDimensions fields from a KQL row.
+// nolint:gocyclo // The branching here is intentional for robust type handling and remains contained.
+// - columns: the table columns (case-insensitive lookup)
+// - row:     the row values aligned with columns
+// Returns the timestamp string (empty if not present), message (if present), and an ordered slice of custom fields.
+func BuildDetails(columns []appinsights.Column, row []interface{}) (string, string, []DetailField) {
+	// Locate relevant columns by name (case-insensitive)
+	idxTimestamp := findColumnIndex(columns, "timestamp")
+	if idxTimestamp < 0 {
+		idxTimestamp = findColumnIndex(columns, "timeGenerated")
+	}
+	idxCustom := findColumnIndex(columns, "customDimensions")
+	idxMessage := findColumnIndex(columns, "message")
+
+	// Extract timestamp string if present
+	ts := ""
+	if idxTimestamp >= 0 && idxTimestamp < len(row) && row[idxTimestamp] != nil {
+		ts = fmt.Sprint(row[idxTimestamp])
+	}
+	// Extract message if present
+	msg := ""
+	if idxMessage >= 0 && idxMessage < len(row) && row[idxMessage] != nil {
+		msg = fmt.Sprint(row[idxMessage])
+	}
+
+	// Extract and normalize customDimensions
+	fields := make([]DetailField, 0)
+	if idxCustom < 0 || idxCustom >= len(row) || row[idxCustom] == nil {
+		// No customDimensions
+		return ts, msg, fields
+	}
+
+	raw := row[idxCustom]
+	// Accept map/object, JSON string, or array. Otherwise stringify.
+	var (
+		root      interface{}
+		parseWarn bool
+		flattened = make(map[string]string)
+		maxDepth  = 2
+	)
+
+	switch v := raw.(type) {
+	case map[string]interface{}:
+		root = v
+	case []interface{}:
+		root = v
+	case string:
+		// Try to parse JSON
+		var tmp interface{}
+		if err := json.Unmarshal([]byte(v), &tmp); err != nil {
+			// Not JSON: show raw string with parse warning
+			parseWarn = true
+			flattened["raw"] = v
+		} else {
+			root = tmp
+		}
+	default:
+		// Unsupported type: stringify under raw
+		parseWarn = true
+		flattened["raw"] = fmt.Sprint(v)
+	}
+
+	if root != nil {
+		// Flatten up to depth=2 using dot/bracket notation
+		flattenInto(flattened, root, "", 0, maxDepth)
+	}
+
+	// Convert map to sorted []DetailField
+	keys := make([]string, 0, len(flattened))
+	for k := range flattened {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		// case-insensitive sort
+		li, lj := strings.ToLower(keys[i]), strings.ToLower(keys[j])
+		if li == lj {
+			return keys[i] < keys[j]
+		}
+		return li < lj
+	})
+
+	// Optionally add a parse warning field at the very top
+	if parseWarn {
+		fields = append(fields, DetailField{Key: "(parse_warning)", Value: "customDimensions is not valid JSON; showing raw string", Group: GroupCustom, Priority: 0})
+	}
+
+	for _, k := range keys {
+		fields = append(fields, DetailField{Key: k, Value: flattened[k], Group: GroupCustom, Priority: 10})
+	}
+
+	return ts, msg, fields
+}
+
+func findColumnIndex(cols []appinsights.Column, name string) int {
+	for i, c := range cols {
+		if strings.EqualFold(strings.TrimSpace(c.Name), name) {
+			return i
+		}
+	}
+	return -1
+}
+
+// flattenInto flattens v into out with keys composed from prefix using dot/bracket notation.
+// Depth is zero-based; when encountering a compound type deeper than maxDepth, stringify as minified JSON.
+// nolint:gocyclo // Depth/type handling benefits from explicit branches; kept readable and tested.
+func flattenInto(out map[string]string, v interface{}, prefix string, depth, maxDepth int) {
+	if v == nil {
+		// Represent null as empty string
+		out[nonEmpty(prefix, "")] = ""
+		return
+	}
+	// If we've exceeded maxDepth and v is compound, stringify
+	if depth > maxDepth {
+		out[nonEmpty(prefix, "")] = jsonCompact(v)
+		return
+	}
+	switch vv := v.(type) {
+	case map[string]interface{}:
+		if len(vv) == 0 {
+			out[nonEmpty(prefix, "")] = "{}"
+			return
+		}
+		// Sort keys for deterministic output
+		ks := make([]string, 0, len(vv))
+		for k := range vv {
+			ks = append(ks, k)
+		}
+		sort.Strings(ks)
+		for _, k := range ks {
+			childKey := k
+			if prefix != "" {
+				childKey = prefix + "." + k
+			}
+			flattenInto(out, vv[k], childKey, depth+1, maxDepth)
+		}
+	case []interface{}:
+		if len(vv) == 0 {
+			out[nonEmpty(prefix, "")] = "[]"
+			return
+		}
+		for i, elem := range vv {
+			idxKey := fmt.Sprintf("%s[%d]", prefix, i)
+			if prefix == "" {
+				idxKey = fmt.Sprintf("[%d]", i)
+			}
+			flattenInto(out, elem, idxKey, depth+1, maxDepth)
+		}
+	case string:
+		out[nonEmpty(prefix, "")] = vv
+	case bool:
+		if vv {
+			out[nonEmpty(prefix, "")] = "true"
+		} else {
+			out[nonEmpty(prefix, "")] = "false"
+		}
+	case float64, float32, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		out[nonEmpty(prefix, "")] = fmt.Sprint(vv)
+	default:
+		// Fallback: stringify via JSON if possible, else fmt
+		s := jsonCompact(v)
+		if s == "" || s == "null" || strings.HasPrefix(s, "<") { // crude detection
+			s = fmt.Sprint(v)
+		}
+		out[nonEmpty(prefix, "")] = s
+	}
+}
+
+func nonEmpty(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return a
+	}
+	return b
+}
+
+// jsonCompact returns a compact JSON representation of v, or fmt.Sprint on failure.
+func jsonCompact(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	return string(b)
+}

--- a/internal/telemetry/details_test.go
+++ b/internal/telemetry/details_test.go
@@ -1,0 +1,83 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/FBakkensen/bc-insights-tui/appinsights"
+)
+
+func col(name string) appinsights.Column { return appinsights.Column{Name: name, Type: "string"} }
+
+func TestBuildDetails_MapObject(t *testing.T) {
+	cols := []appinsights.Column{col("timestamp"), col("message"), col("customDimensions")}
+	row := []interface{}{"2025-01-01T00:00:00Z", "hello", map[string]interface{}{
+		"a":    1,
+		"b":    true,
+		"c":    "str",
+		"nest": map[string]interface{}{"x": 2, "y": []interface{}{1, 2}},
+	}}
+	ts, msg, fields := BuildDetails(cols, row)
+	if ts == "" {
+		t.Fatalf("expected timestamp")
+	}
+	if msg == "" {
+		t.Fatalf("expected message present when message column exists")
+	}
+	// Ensure keys exist after flatten
+	wantKeys := []string{"a", "b", "c", "nest.x", "nest.y[0]", "nest.y[1]"}
+	got := map[string]bool{}
+	for _, f := range fields {
+		got[f.Key] = true
+	}
+	for _, k := range wantKeys {
+		if !got[k] {
+			t.Fatalf("missing key %s", k)
+		}
+	}
+}
+
+func TestBuildDetails_JSONString(t *testing.T) {
+	cols := []appinsights.Column{col("timeGenerated"), col("customDimensions")}
+	m := map[string]interface{}{"x": 1, "y": []interface{}{"a", 2}}
+	b, _ := json.Marshal(m)
+	row := []interface{}{"2025-02-02T00:00:00Z", string(b)}
+	_, _, fields := BuildDetails(cols, row)
+	keys := map[string]bool{}
+	for _, f := range fields {
+		keys[f.Key] = true
+	}
+	if !keys["x"] || !keys["y[0]"] || !keys["y[1]"] {
+		t.Fatalf("expected flattened keys from JSON string")
+	}
+}
+
+func TestBuildDetails_InvalidJSONString_ShowsRaw(t *testing.T) {
+	cols := []appinsights.Column{col("timestamp"), col("customDimensions")}
+	row := []interface{}{"t", "not-json"}
+	_, _, fields := BuildDetails(cols, row)
+	if len(fields) == 0 {
+		t.Fatalf("expected fields including raw")
+	}
+	if fields[0].Key != "(parse_warning)" {
+		t.Fatalf("expected parse warning at first field")
+	}
+	hasRaw := false
+	for _, f := range fields {
+		if f.Key == "raw" {
+			hasRaw = true
+		}
+	}
+	if !hasRaw {
+		t.Fatalf("expected raw field present")
+	}
+}
+
+func TestBuildDetails_NoCustomColumn(t *testing.T) {
+	cols := []appinsights.Column{col("timestamp"), col("message")}
+	row := []interface{}{"t", "m"}
+	_, _, fields := BuildDetails(cols, row)
+	if len(fields) != 0 {
+		t.Fatalf("expected no custom fields when column missing")
+	}
+}

--- a/tui/model.go
+++ b/tui/model.go
@@ -79,9 +79,18 @@ type model struct {
 	haveResults  bool
 	runningKQL   bool
 
+	// normalized display headers for list views (timestamp, message, customDimensions keys)
+	lastDisplayHeaders []string
+
 	// editor (Step 6)
 	editorDesiredHeight int
 	origPrompt          string
+
+	// details view (Step 9)
+	detailsVP      viewport.Model
+	detailsStart   time.Time
+	detailsContent string
+	detailsRow     int
 }
 
 type uiMode int
@@ -97,6 +106,7 @@ const (
 	modeListSubscriptions
 	modeListInsightsResources
 	modeTableResults
+	modeDetails
 )
 
 // config keys used in TUI (mirror of config.settingAzureSubscriptionID)
@@ -175,6 +185,7 @@ func initialModel(cfg config.Config) model {
 		kqlClient:           nil,
 		editorDesiredHeight: 8,
 		origPrompt:          promptDefault,
+		detailsVP:           viewport.New(80, 20),
 	}
 	m.append("Welcome to bc-insights-tui (chat-first).")
 	m.append("Step 1: Login using Azure Device Flow.")

--- a/tui/ui_details_test.go
+++ b/tui/ui_details_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/FBakkensen/bc-insights-tui/appinsights"
+	"github.com/FBakkensen/bc-insights-tui/auth"
+)
+
+func TestDetails_OpenAndClose_FromTable(t *testing.T) {
+	m := newTestModel()
+	m.authState = auth.AuthStateCompleted
+
+	// Seed last results with a customDimensions column and one row
+	cols := []appinsights.Column{{Name: "timestamp"}, {Name: "message"}, {Name: "customDimensions"}}
+	row := []interface{}{"2025-03-03T00:00:00Z", "hello world", map[string]interface{}{"foo": "bar", "nested": map[string]interface{}{"x": 1}}}
+	m.lastColumns = cols
+	m.lastRows = [][]interface{}{row}
+	m.lastTable = "PrimaryResult"
+	m.haveResults = true
+
+	// Open table interactively via F6
+	m2Any, _ := m.Update(tea.KeyMsg{Type: tea.KeyF6})
+	m2 := m2Any.(model)
+	if m2.mode != modeTableResults {
+		t.Fatalf("expected table mode after F6; got %v", m2.mode)
+	}
+
+	// Press Enter to open details for selected row 0
+	m3Any, _ := m2.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m3 := m3Any.(model)
+	if m3.mode != modeDetails {
+		t.Fatalf("expected modeDetails after Enter; got %v", m3.mode)
+	}
+	view := m3.detailsVP.View()
+	// Basic header marker and sections present
+	if !strings.Contains(view, "Details — PrimaryResult · row 0") {
+		t.Fatalf("expected header with table and row index; got: %q", view)
+	}
+	if !strings.Contains(view, "timestamp: 2025-03-03T00:00:00Z") {
+		t.Fatalf("expected timestamp line; got: %q", view)
+	}
+	if !strings.Contains(view, "message: hello world") {
+		t.Fatalf("expected message line; got: %q", view)
+	}
+	if !strings.Contains(view, "customDimensions:") {
+		t.Fatalf("expected customDimensions section; got: %q", view)
+	}
+	// At least one flattened key
+	if !strings.Contains(view, "foo: bar") {
+		t.Fatalf("expected flattened key foo: bar; got: %q", view)
+	}
+
+	// Close details with Esc back to table
+	m4Any, _ := m3.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m4 := m4Any.(model)
+	if m4.mode != modeTableResults {
+		t.Fatalf("expected to return to table after Esc; got %v", m4.mode)
+	}
+}

--- a/tui/ui_headers_test.go
+++ b/tui/ui_headers_test.go
@@ -1,0 +1,154 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/FBakkensen/bc-insights-tui/appinsights"
+	"github.com/FBakkensen/bc-insights-tui/auth"
+)
+
+// Build a KQL result where customDimensions vary across rows to ensure unioning works
+func TestHeaders_BuildFromAllRows_UnionKeys(t *testing.T) {
+	cols := []appinsights.Column{{Name: "timestamp"}, {Name: "message"}, {Name: "customDimensions"}}
+	rows := [][]interface{}{
+		{"2025-01-01T00:00:00Z", "a", `{"k1":"v1","k2":"v2"}`},
+		{"2025-01-01T00:01:00Z", "b", map[string]interface{}{"k2": "v22", "k3": "v3"}},
+	}
+	headers := buildHeadersForAllRows(cols, rows)
+	if len(headers) != 5 { // timestamp, message, k1, k2, k3
+		t.Fatalf("expected 5 headers, got %d: %v", len(headers), headers)
+	}
+	if headers[0] != "timestamp" || headers[1] != "message" {
+		t.Fatalf("expected first headers timestamp,message; got %v", headers[:2])
+	}
+	// order of custom keys is sorted
+	custom := headers[2:]
+	want := []string{"k1", "k2", "k3"}
+	if strings.Join(custom, ",") != strings.Join(want, ",") {
+		t.Fatalf("expected custom keys %v, got %v", want, custom)
+	}
+}
+
+func TestSnapshot_And_Interactive_UseCanonicalHeaders(t *testing.T) {
+	// Construct columns with extra fields that should be ignored
+	cols := []appinsights.Column{{Name: "timestamp"}, {Name: "message"}, {Name: "customDimensions"}, {Name: "ignored"}}
+	rows := [][]interface{}{
+		{"2025-01-01T00:00:00Z", "hello", `{"x":1}`, "zzz"},
+		{"2025-01-01T00:01:00Z", "world", `{"y":2}`, 123},
+	}
+	m := newTestModel()
+	m.authState = auth.AuthStateCompleted
+	// store results
+	m2Any, _ := m.Update(kqlResultMsg{tableName: "PrimaryResult", columns: cols, rows: rows})
+	m2 := m2Any.(model)
+	if len(m2.lastDisplayHeaders) != 4 { // timestamp, message, x, y
+		t.Fatalf("expected 4 canonical headers; got %d: %v", len(m2.lastDisplayHeaders), m2.lastDisplayHeaders)
+	}
+	// Render snapshot: should not contain "ignored"
+	snap := m2.renderSnapshot(cols, rows)
+	if strings.Contains(snap, "ignored") {
+		t.Fatalf("snapshot should not include non-target column 'ignored'")
+	}
+	if !strings.Contains(snap, "timestamp") || !strings.Contains(snap, "message") {
+		t.Fatalf("snapshot should include timestamp and message headers: %q", snap)
+	}
+
+	// Open interactive and check the header row view contains only canonical headers
+	m3Any, _ := m2.Update(tea.KeyMsg{Type: tea.KeyF6})
+	m3 := m3Any.(model)
+	view := m3.tbl.View()
+	if strings.Contains(view, "ignored") {
+		t.Fatalf("interactive view should not include non-target column 'ignored'")
+	}
+	// Ensure at least one custom key header is present
+	if !strings.Contains(view, "x") || !strings.Contains(view, "y") {
+		t.Fatalf("interactive header should include discovered custom keys: %q", view)
+	}
+}
+
+// When width is constrained, we show as many canonical headers as fit and add an ellipsis column (+N)
+// where N equals the count of hidden canonical headers. This test forces a narrow width.
+func TestSnapshot_EllipsisCount_FromCanonicalHeaders(t *testing.T) {
+	cols := []appinsights.Column{{Name: "timestamp"}, {Name: "message"}, {Name: "customDimensions"}}
+	rows := [][]interface{}{
+		{"2025-01-01T00:00:00Z", "m0", `{"a":1,"b":2,"c":3,"d":4}`},
+		{"2025-01-01T00:01:00Z", "m1", `{"a":11,"c":33,"e":5}`},
+	}
+	m := newTestModel()
+	m.authState = auth.AuthStateCompleted
+	// Shrink viewport width to force truncation. minColWidth is 14 => width 42 fits 3 columns max.
+	// With ellipsis, dataCols = visibleCols-1 = 2, leaving (+N) as third.
+	m.vp.Width = 42
+
+	m2Any, _ := m.Update(kqlResultMsg{tableName: "PrimaryResult", columns: cols, rows: rows})
+	m2 := m2Any.(model)
+	// Canonical headers are timestamp, message, and union of {a,b,c,d,e} => 7 total
+	if len(m2.lastDisplayHeaders) != 7 {
+		t.Fatalf("expected 7 headers; got %d: %v", len(m2.lastDisplayHeaders), m2.lastDisplayHeaders)
+	}
+	snap := m2.renderSnapshot(cols, rows)
+	// With width=42, visibleCols = 3, dataCols=2, so hidden = 7-2 = 5
+	if !strings.Contains(snap, "(+5)") {
+		t.Fatalf("expected snapshot ellipsis '(+5)' reflecting hidden canonical headers; got: %q", snap)
+	}
+}
+
+func TestInteractive_EllipsisCount_FromCanonicalHeaders(t *testing.T) {
+	cols := []appinsights.Column{{Name: "timestamp"}, {Name: "message"}, {Name: "customDimensions"}}
+	rows := [][]interface{}{
+		{"2025-01-01T00:00:00Z", "m0", `{"a":1,"b":2,"c":3,"d":4}`},
+		{"2025-01-01T00:01:00Z", "m1", `{"a":11,"c":33,"e":5}`},
+	}
+	m := newTestModel()
+	m.authState = auth.AuthStateCompleted
+	m.vp.Width = 42
+	// Produce results and then open interactive (F6)
+	m2Any, _ := m.Update(kqlResultMsg{tableName: "PrimaryResult", columns: cols, rows: rows})
+	m2 := m2Any.(model)
+	m3Any, _ := m2.Update(tea.KeyMsg{Type: tea.KeyF6})
+	m3 := m3Any.(model)
+	view := m3.tbl.View()
+	// Same calculation: 7 total headers, dataCols=2 => hidden = 5
+	if !strings.Contains(view, "(+5)") {
+		t.Fatalf("expected interactive ellipsis '(+5)' reflecting hidden canonical headers; got: %q", view)
+	}
+}
+
+// Ensure we de-duplicate custom keys case-insensitively and prefer first-seen casing,
+// while mapping values regardless of later rows using different case.
+func TestHeaders_CaseInsensitive_Dedup_And_ValueMapping(t *testing.T) {
+	cols := []appinsights.Column{{Name: "timestamp"}, {Name: "message"}, {Name: "customDimensions"}}
+	rows := [][]interface{}{
+		{"2025-01-01T00:00:00Z", "m0", `{"Foo": "A", "bar": 1}`},
+		{"2025-01-01T00:01:00Z", "m1", `{"foo": "B", "Bar": 2}`},
+	}
+	m := newTestModel()
+	m.authState = auth.AuthStateCompleted
+	m.vp.Width = 200
+	m2Any, _ := m.Update(kqlResultMsg{tableName: "PrimaryResult", columns: cols, rows: rows})
+	m2 := m2Any.(model)
+
+	headers := m2.lastDisplayHeaders
+	// Verify consolidated headers contain 'bar' and 'foo' once each, case-insensitively
+	custom := headers[2:]
+	seenLower := map[string]bool{}
+	for _, h := range custom {
+		seenLower[strings.ToLower(h)] = true
+	}
+	if !seenLower["bar"] || !seenLower["foo"] {
+		t.Fatalf("expected consolidated headers to include 'bar' and 'foo' (any casing); got %v", headers)
+	}
+	// Ensure there are no duplicates case-insensitively
+	if len(seenLower) != len(custom) {
+		t.Fatalf("expected no duplicate custom headers (case-insensitive); got %v", headers)
+	}
+
+	// Render snapshot and ensure values appear irrespective of case in row
+	out := m2.renderSnapshot(cols, rows)
+	if !strings.Contains(out, "A") || !strings.Contains(out, "B") {
+		t.Fatalf("expected both values A and B for key 'foo/ Foo' to appear; got: %q", out)
+	}
+}

--- a/tui/ui_test.go
+++ b/tui/ui_test.go
@@ -51,6 +51,9 @@ func newTestModel() model {
 		maxContentWidth: 120,
 		followTail:      true,
 	}
+	// Initialize details viewport to sane defaults used by view
+	m.detailsVP = viewport.New(80, 10)
+	m.detailsVP.SetContent("")
 	return m
 }
 

--- a/tui/view.go
+++ b/tui/view.go
@@ -15,6 +15,8 @@ func (m model) View() string {
 		top = m.vpStyle.Render(m.list.View())
 	case modeTableResults:
 		top = m.vpStyle.Render(m.tbl.View())
+	case modeDetails:
+		top = m.vpStyle.Render(m.detailsVP.View())
 	case modeKQLEditor:
 		// Show scrollback in top area while editing
 		top = m.vpStyle.Render(m.vp.View())


### PR DESCRIPTION
This pull request introduces a configurable fetch limit for Application Insights KQL queries and improves the debugging capture mechanism for raw API requests and responses. The fetch limit is now applied automatically to queries when appropriate, and raw debug captures support file rotation based on a configurable maximum number of files. Logging for debug captures has also been refined, and new tests ensure correct fetch limit logic.

**Query Fetch Limit Feature:**

* Added a `fetchLimit` field to the `Client` struct and logic to automatically append a `| take <fetchLimit>` clause to KQL queries, unless the query already specifies a limit/take or does not start with a known table. This helps prevent excessive data retrieval and enforces consistent query limits. [[1]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36R46-R51) [[2]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36R79-R100) [[3]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36L221-R341)
* Implemented the `applyFetchLimitIfNeeded` and `maybeApplyFetchLimit` functions to encapsulate the fetch limit logic, with detailed logging for decision outcomes.

**Raw Debug Capture Improvements:**

* Added support for rotating raw debug capture files using the new `DebugAppInsightsRawKeepN` config value, which controls the number of files to retain. Capture functions now accept and use this value, and file rotation is performed when enabled. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R75) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R101) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R210-R214) [[4]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36R46-R51) [[5]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36L159-R189) [[6]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36L187-R218) F16eb604L453R500)
* Refactored raw capture config handling to use a snapshot from the client, improving efficiency and consistency. [[1]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36R46-R51) [[2]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36R79-R100) [[3]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36L235-R351)

**Logging and Testing Enhancements:**

* Changed debug capture logging from `Info` to `Debug` level for less noisy logs. (F16eb604L428R428, F16eb604L453R453, F16eb604L500R500)
* Added comprehensive unit tests for the fetch limit logic, covering various edge cases and ensuring correct application of the limit.

**Configuration Updates:**

* Added `DebugAppInsightsRawKeepN` to the config struct, default values, and environment variable parsing, enabling users to control file rotation for raw captures. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R75) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R101) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R210-R214)

**API and Internal Refactoring:**

* Updated function signatures for capture helpers to pass and use the new parameters (`startedAt`, `keepN`), and improved context handling for request timing. [[1]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36L137-R172) [[2]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36L159-R189) [[3]](diffhunk://#diff-1a1295bd3066a680ef9d999579d1e1f9cfce100dece9fdb1ba2b34eb88afcd36L187-R218) F16eb604L401R401, F16eb604L413R413, F16eb604L442R442, F16eb604L453R453, F16eb604L479R479)

Let me know if you want a deeper dive into any of these changes!